### PR TITLE
SCA: Upgrade commons-dbcp component from 1.2.2 to 20030825.184428

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
 		<dependency>
 			<groupId>commons-dbcp</groupId>
 			<artifactId>commons-dbcp</artifactId>
-			<version>1.2.2</version>
+			<version>20030825.184428</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-pool</groupId>


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the commons-dbcp component version 1.2.2. The recommended fix is to upgrade to version 20030825.184428.

