### PR TITLE
SCA: Upgrade ldapsdk component from 5.1.0 to 6.0.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
 		<dependency>
 			<groupId>com.unboundid</groupId>
 			<artifactId>unboundid-ldapsdk</artifactId>
-			<version>5.1.0</version>
+			<version>6.0.11</version>
 		</dependency>
 
 		<!-- Testing -->


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the ldapsdk component version 5.1.0. The recommended fix is to upgrade to version 6.0.11.

