### PR TITLE
SCA: Upgrade Apache Commons FileUpload component from 1.3.3 to 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
 		<dependency>
 			<groupId>commons-fileupload</groupId>
 			<artifactId>commons-fileupload</artifactId>
-			<version>1.3.3</version>
+			<version>1.5</version>
 		</dependency>
 		<!-- Spring Security -->
 		<dependency>


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the Apache Commons FileUpload component version 1.3.3. The recommended fix is to upgrade to version 1.5.

