### PR TITLE
SCA: Upgrade JavaServer Pages(TM) API component from 2.3.1 to 2.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
 		<dependency>
 			<groupId>javax.servlet.jsp</groupId>
 			<artifactId>javax.servlet.jsp-api</artifactId>
-			<version>2.3.1</version>
+			<version>2.3.3</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- JSR 303 with Hibernate Validator -->


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the JavaServer Pages(TM) API component version 2.3.1. The recommended fix is to upgrade to version 2.3.3.

