### PR TITLE
SCA: Upgrade beanvalidation-api component from 1.0.0 to 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
 		<dependency>
 			<groupId>javax.validation</groupId>
 			<artifactId>validation-api</artifactId>
-			<version>1.0.0.GA</version>
+			<version>2.0.1.GA</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate</groupId>


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the beanvalidation-api component version 1.0.0. The recommended fix is to upgrade to version 2.0.1.

