### PR TITLE
SCA: Upgrade JavaServer Pages (TM) TagLib Implementation component from 1.2 to 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>jstl</artifactId>
-			<version>1.2</version>
+			<version></version>
 		</dependency>
 		<!-- Servlet API -->
 		<dependency>


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the JavaServer Pages (TM) TagLib Implementation component version 1.2. The recommended fix is to upgrade to version .

