### PR TITLE
SCA: Upgrade Hibernate Validator component from 4.3.2.Final to 5.4.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>4.3.2.Final</version>
+			<version>5.4.3.Final</version>
 		</dependency>
 		<!-- JAXB -->
 		<dependency>


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the Hibernate Validator component version 4.3.2.Final. The recommended fix is to upgrade to version 5.4.3.Final.

