### PR TITLE
SCA: Upgrade jaxb-api component from 2.3.0 to 2.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
 		<dependency>
 			<groupId>javax.xml.bind</groupId>
 			<artifactId>jaxb-api</artifactId>
-			<version>2.3.0</version>
+			<version>2.3.1</version>
 		</dependency>
 		<!-- Database -->
 		<dependency>


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the jaxb-api component version 2.3.0. The recommended fix is to upgrade to version 2.3.1.

