### PR TITLE
SCA: Upgrade BoneCP component from 0.8.0.RELEASE to 0.8.0.RELEASE-redhat-006

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
 		<dependency>
 			<groupId>com.jolbox</groupId>
 			<artifactId>bonecp</artifactId>
-			<version>0.8.0.RELEASE</version>
+			<version>0.8.0.RELEASE-redhat-006</version>
 		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the BoneCP component version 0.8.0.RELEASE. The recommended fix is to upgrade to version 0.8.0.RELEASE-redhat-006.

