### PR TITLE
SCA: Upgrade JUnit component from 4.13.1 to 4.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the JUnit component version 4.13.1. The recommended fix is to upgrade to version 4.13.2.

