### PR TITLE
SCA: Upgrade Java Servlet API component from 3.1.0 to 4.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
-			<version>3.1.0</version>
+			<version>4.0.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the Java Servlet API component version 3.1.0. The recommended fix is to upgrade to version 4.0.1.

