### PR TITLE
SCA: Upgrade Apache Commons Pool component from 1.5.3 to 20030825.183949

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
 		<dependency>
 			<groupId>commons-pool</groupId>
 			<artifactId>commons-pool</artifactId>
-			<version>1.5.3</version>
+			<version>20030825.183949</version>
 		</dependency>
 		<!-- Logging -->
 		<dependency>


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the Apache Commons Pool component version 1.5.3. The recommended fix is to upgrade to version 20030825.183949.

