### PR TITLE
SCA: Upgrade Apache Log4j SLF4J Binding component from 2.14.1 to 2.24.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>2.14.1</version>
+			<version>2.24.3</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-fileupload</groupId>


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the Apache Log4j SLF4J Binding component version 2.14.1. The recommended fix is to upgrade to version 2.24.3.

