### PR TITLE
SCA: Upgrade PostgreSQL JDBC Driver (pgjdbc) component from 9.2-1004-jdbc4 to 42.7.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>9.2-1004-jdbc4</version>
+			<version>42.7.5</version>
 		</dependency>
 		<!-- HSQLDB -->
 		<dependency>


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the PostgreSQL JDBC Driver (pgjdbc) component version 9.2-1004-jdbc4. The recommended fix is to upgrade to version 42.7.5.

