### PR TITLE
SCA: Upgrade Spring Framework component from 4.2.3.RELEASE to 6.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<name>Insecure Bank</name>
 
 	<properties>
-		<org.springframework-version>4.2.3.RELEASE</org.springframework-version>
+		<org.springframework-version>6.2.2</org.springframework-version>
 		<org.spring-security-version>4.0.3.RELEASE</org.spring-security-version>
 		<org.slf4j-version>1.7.13</org.slf4j-version>
 	</properties>


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the Spring Framework component version 4.2.3.RELEASE. The recommended fix is to upgrade to version 6.2.2.

