### PR TITLE
SCA: Upgrade Spring Security component from 4.0.3.RELEASE to 6.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<properties>
 		<org.springframework-version>4.2.3.RELEASE</org.springframework-version>
-		<org.spring-security-version>4.0.3.RELEASE</org.spring-security-version>
+		<org.spring-security-version>6.4.2</org.spring-security-version>
 		<org.slf4j-version>1.7.13</org.slf4j-version>
 	</properties>
 


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the Spring Security component version 4.0.3.RELEASE. The recommended fix is to upgrade to version 6.4.2.

