### PR TITLE
SCA: Upgrade HyperSQL Database Engine component from 2.3.4 to 2.7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
-			<version>2.3.4</version>
+			<version>2.7.4</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-dbcp</groupId>


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the HyperSQL Database Engine component version 2.3.4. The recommended fix is to upgrade to version 2.7.4.

